### PR TITLE
SPI: receive and transmit multiple bytes

### DIFF
--- a/hardware/arm/EFM32/libraries/spidrv/src/SPI.h
+++ b/hardware/arm/EFM32/libraries/spidrv/src/SPI.h
@@ -36,14 +36,26 @@ public:
   }
 
   // Write to the SPI bus (MOSI pin) and also receive (MISO pin)
-  inline uint8_t transfer(__attribute__((unused)) uint8_t data) {
+  inline uint8_t transfer(uint8_t data) {
     uint8_t ret;
-     SPIDRV_MTransferSingleItemB(spidrvHandle, data, &ret);
+    SPIDRV_MTransferSingleItemB(spidrvHandle, data, &ret);
     return ret;
   }
   inline static uint16_t transfer16(__attribute__((unused)) uint16_t data) { return 0;
   }
   inline static void transfer(__attribute__((unused)) void *buf, __attribute__((unused)) size_t count) {
+  }
+  // Write and read multiple bytes (blocking)
+  inline void transfer(void *bufTx, void *bufRx, size_t count) {
+    SPIDRV_MTransferB(spidrvHandle, bufTx, bufRx, count);
+  }
+  // Read multiple bytes (blocking)
+  inline void receive(void *bufRx, size_t count) {
+    SPIDRV_MReceiveB(spidrvHandle, bufRx, count);
+  }
+  // Write multiple bytes (blocking)
+  inline void transmit(void *bufTx, size_t count) {
+    SPIDRV_MTransmitB(spidrvHandle, bufTx, count);
   }
   // After performing a group of transfers and releasing the chip select
   // signal, this function allows others to access the SPI bus


### PR DESCRIPTION
Read, write or read+write multiple bytes in one transfer.

Loop of single transfers (24 bytes)
![grafik](https://user-images.githubusercontent.com/4477518/176920256-b7976a0b-2d53-4469-a956-1436f42b5e0c.png)

Multi-transfer (14 bytes)
![grafik](https://user-images.githubusercontent.com/4477518/176920420-d8c8bb25-05d6-4100-b6fc-f1dc6286af17.png)

The time scale is the same. Even though the first transfer has more bytes, the speed improvement is clearly visible.